### PR TITLE
Updates to shutdown from shutdownAsync

### DIFF
--- a/contents/docs/libraries/svelte.md
+++ b/contents/docs/libraries/svelte.md
@@ -103,11 +103,11 @@ export async function load() {
     distinctId: 'distinct_id_of_the_user',
     event: 'event_name',
   })
-  await posthog.shutdownAsync()
+  await posthog.shutdown()
 }
 ```
 
-> **Note:** Make sure to always call `posthog.shutdownAsync()` after capturing events from the server-side. PostHog queues events into larger batches, and this call forces all batched events to be flushed immediately.
+> **Note:** Make sure to always call `posthog.shutdown()` after capturing events from the server-side. PostHog queues events into larger batches, and this call forces all batched events to be flushed immediately.
 
 ## Next steps
 


### PR DESCRIPTION
This node / svelte doc referred to a shutdownAsync method that seems to no longer exist in the posthog client. This updates mentions of that to the shutdown method.

## Changes

*Please describe.*

*Add screenshots or screen recordings for visual / UI-focused changes.*

## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)

## Useful resources

- [The PostHog style guide](https://posthog.com/handbook/growth/marketing/posthog-style-guide)
- [Full list of tags and categories](https://posthog.com/handbook/growth/marketing/tags-and-categories)
- [List of content components](https://posthog.com/handbook/growth/marketing/components)
- [PostHog SEO best practices](https://posthog.com/handbook/growth/marketing/seo-guide)
